### PR TITLE
Add binary support to the Json mapper

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapper.java
@@ -46,6 +46,7 @@ import org.wso2.siddhi.query.api.definition.Attribute;
 import org.wso2.siddhi.query.api.definition.StreamDefinition;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -187,15 +188,25 @@ public class JsonSourceMapper extends SourceMapper {
     /**
      * Convert the given JSON string to {@link Event}.
      *
-     * @param eventObject JSON string
+     * @param eventObject JSON string or JSON string as a byte array.
      * @return the constructed Event object
      */
     private Object convertToEvent(Object eventObject) {
-        if (!(eventObject instanceof String)) {
+
+        if (!(eventObject instanceof String || eventObject instanceof byte[])) {
             log.error("Invalid JSON object received. Expected String, but found " +
                     eventObject.getClass()
                             .getCanonicalName());
             return null;
+        }
+
+        if (eventObject instanceof byte[]) {
+            try {
+                eventObject = new String((byte[]) eventObject, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                log.error("Error is encountered while decoding the byte stream. Please note that only UTF-8 "
+                        + "encoding is supported" + e.getMessage(), e);
+            }
         }
 
         if (!isJsonValid(eventObject.toString())) {
@@ -464,7 +475,7 @@ public class JsonSourceMapper extends SourceMapper {
 
     @Override
     public Class[] getSupportedInputEventClasses() {
-        return new Class[]{String.class};
+        return new Class[]{String.class, byte[].class};
     }
 
     /**

--- a/component/src/test/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapperTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapperTestCase.java
@@ -30,6 +30,7 @@ import org.wso2.siddhi.core.util.EventPrinter;
 import org.wso2.siddhi.core.util.SiddhiTestHelper;
 import org.wso2.siddhi.core.util.transport.InMemoryBroker;
 
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class JsonSourceMapperTestCase {
@@ -909,6 +910,83 @@ public class JsonSourceMapperTestCase {
                 "       {\"stock\":{\"volume\":200,\"company\":{\"symbol\":null},\"price\":77.6}}" +
                 "   ]\n" +
                 "}\n");
+        SiddhiTestHelper.waitForEvents(waitTime, 6, count, timeout);
+        //assert event count
+        AssertJUnit.assertEquals("Number of events", 6, count.get());
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void jsonSourceMapperTest14() throws InterruptedException {
+        log.info("test JsonSourceMapper 14");
+        String streams = "" +
+                "@App:name('TestSiddhiApp')" +
+                "@source(type='inMemory', topic='stock', " +
+                "@map(type='json', enclosing.element=\"portfolio\", " +
+                "fail.on.missing.attribute=\"false\", " +
+                "@attributes(symbol = \"stock.company.symbol\", price = \"stock.price\", " +
+                "volume = \"stock.volume\"))) " +
+                "define stream FooStream (symbol string, price float, volume long); " +
+                "define stream BarStream (symbol string, price float, volume long); ";
+        String query = "" +
+                "from FooStream " +
+                "select * " +
+                "insert into BarStream; ";
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        siddhiAppRuntime.addCallback("BarStream", new StreamCallback() {
+
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    switch (count.incrementAndGet()) {
+                    case 1:
+                        AssertJUnit.assertEquals(55.6f, event.getData(1));
+                        break;
+                    case 2:
+                        AssertJUnit.assertEquals(56.6f, event.getData(1));
+                        break;
+                    case 3:
+                        AssertJUnit.assertEquals(100L, event.getData(2));
+                        break;
+                    case 4:
+                        AssertJUnit.assertEquals(200L, event.getData(2));
+                        break;
+                    case 5:
+                        AssertJUnit.assertEquals("wso2", event.getData(0));
+                        break;
+                    case 6:
+                        AssertJUnit.assertEquals(null, event.getData(0));
+                        break;
+                    default:
+                        AssertJUnit.fail();
+                    }
+                }
+            }
+        });
+        siddhiAppRuntime.start();
+        InMemoryBroker.publish("stock", ("\n" +
+                "{\"portfolio\":\n" +
+                "   [" +
+                "       {\"stock\":{\"volume\":100,\"company\":{\"symbol\":\"wso2\"},\"price\":55.6}}," +
+                "       {\"stock\":{\"volume\":null,\"company\":{\"symbol\":\"IBM\"},\"price\":56.6}}" +
+                "   ]\n" +
+                "}\n").getBytes(StandardCharsets.UTF_8));
+        InMemoryBroker.publish("stock", ("\n" +
+                "{\"portfolio\":\n" +
+                "   [" +
+                "       {\"stock\":{\"volume\":100,\"company\":{\"symbol\":\"wso2\"},\"price\":66.6}}," +
+                "       {\"stock\":{\"volume\":200,\"company\":{\"symbol\":\"IBM\"},\"price\":null}}" +
+                "   ]\n" +
+                "}\n").getBytes(StandardCharsets.UTF_8));
+        InMemoryBroker.publish("stock", ("\n" +
+                "{\"portfolio\":\n" +
+                "   [" +
+                "       {\"stock\":{\"volume\":100,\"company\":{\"symbol\":\"wso2\"},\"price\":76.6}}," +
+                "       {\"stock\":{\"volume\":200,\"company\":{\"symbol\":null},\"price\":77.6}}" +
+                "   ]\n" +
+                "}\n").getBytes(StandardCharsets.UTF_8));
         SiddhiTestHelper.waitForEvents(waitTime, 6, count, timeout);
         //assert event count
         AssertJUnit.assertEquals("Number of events", 6, count.get());

--- a/component/src/test/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapperTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapperTestCase.java
@@ -918,83 +918,6 @@ public class JsonSourceMapperTestCase {
 
     @Test
     public void jsonSourceMapperTest14() throws InterruptedException {
-        log.info("test JsonSourceMapper 14");
-        String streams = "" +
-                "@App:name('TestSiddhiApp')" +
-                "@source(type='inMemory', topic='stock', " +
-                "@map(type='json', enclosing.element=\"portfolio\", " +
-                "fail.on.missing.attribute=\"false\", " +
-                "@attributes(symbol = \"stock.company.symbol\", price = \"stock.price\", " +
-                "volume = \"stock.volume\"))) " +
-                "define stream FooStream (symbol string, price float, volume long); " +
-                "define stream BarStream (symbol string, price float, volume long); ";
-        String query = "" +
-                "from FooStream " +
-                "select * " +
-                "insert into BarStream; ";
-        SiddhiManager siddhiManager = new SiddhiManager();
-        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        siddhiAppRuntime.addCallback("BarStream", new StreamCallback() {
-
-            @Override
-            public void receive(Event[] events) {
-                EventPrinter.print(events);
-                for (Event event : events) {
-                    switch (count.incrementAndGet()) {
-                    case 1:
-                        AssertJUnit.assertEquals(55.6f, event.getData(1));
-                        break;
-                    case 2:
-                        AssertJUnit.assertEquals(56.6f, event.getData(1));
-                        break;
-                    case 3:
-                        AssertJUnit.assertEquals(100L, event.getData(2));
-                        break;
-                    case 4:
-                        AssertJUnit.assertEquals(200L, event.getData(2));
-                        break;
-                    case 5:
-                        AssertJUnit.assertEquals("wso2", event.getData(0));
-                        break;
-                    case 6:
-                        AssertJUnit.assertEquals(null, event.getData(0));
-                        break;
-                    default:
-                        AssertJUnit.fail();
-                    }
-                }
-            }
-        });
-        siddhiAppRuntime.start();
-        InMemoryBroker.publish("stock", ("\n" +
-                "{\"portfolio\":\n" +
-                "   [" +
-                "       {\"stock\":{\"volume\":100,\"company\":{\"symbol\":\"wso2\"},\"price\":55.6}}," +
-                "       {\"stock\":{\"volume\":null,\"company\":{\"symbol\":\"IBM\"},\"price\":56.6}}" +
-                "   ]\n" +
-                "}\n").getBytes(StandardCharsets.UTF_8));
-        InMemoryBroker.publish("stock", ("\n" +
-                "{\"portfolio\":\n" +
-                "   [" +
-                "       {\"stock\":{\"volume\":100,\"company\":{\"symbol\":\"wso2\"},\"price\":66.6}}," +
-                "       {\"stock\":{\"volume\":200,\"company\":{\"symbol\":\"IBM\"},\"price\":null}}" +
-                "   ]\n" +
-                "}\n").getBytes(StandardCharsets.UTF_8));
-        InMemoryBroker.publish("stock", ("\n" +
-                "{\"portfolio\":\n" +
-                "   [" +
-                "       {\"stock\":{\"volume\":100,\"company\":{\"symbol\":\"wso2\"},\"price\":76.6}}," +
-                "       {\"stock\":{\"volume\":200,\"company\":{\"symbol\":null},\"price\":77.6}}" +
-                "   ]\n" +
-                "}\n").getBytes(StandardCharsets.UTF_8));
-        SiddhiTestHelper.waitForEvents(waitTime, 6, count, timeout);
-        //assert event count
-        AssertJUnit.assertEquals("Number of events", 6, count.get());
-        siddhiAppRuntime.shutdown();
-    }
-
-    @Test
-    public void jsonSourceMapperTest14() throws InterruptedException {
         log.info("test JsonSourceMapper with test multiple event");
         String streams = "" +
                 "@App:name('TestSiddhiApp')" +
@@ -1278,6 +1201,83 @@ public class JsonSourceMapperTestCase {
         siddhiAppRuntime.start();
         InMemoryBroker.publish("stock", 12);
         AssertJUnit.assertTrue(appender.getMessages().contains("Invalid JSON object received. Expected String"));
+        siddhiAppRuntime.shutdown();
+    }
+
+    @Test
+    public void jsonSourceMapperTest22() throws InterruptedException {
+        log.info("test JsonSourceMapper 14");
+        String streams = "" +
+                "@App:name('TestSiddhiApp')" +
+                "@source(type='inMemory', topic='stock', " +
+                "@map(type='json', enclosing.element=\"portfolio\", " +
+                "fail.on.missing.attribute=\"false\", " +
+                "@attributes(symbol = \"stock.company.symbol\", price = \"stock.price\", " +
+                "volume = \"stock.volume\"))) " +
+                "define stream FooStream (symbol string, price float, volume long); " +
+                "define stream BarStream (symbol string, price float, volume long); ";
+        String query = "" +
+                "from FooStream " +
+                "select * " +
+                "insert into BarStream; ";
+        SiddhiManager siddhiManager = new SiddhiManager();
+        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
+        siddhiAppRuntime.addCallback("BarStream", new StreamCallback() {
+
+            @Override
+            public void receive(Event[] events) {
+                EventPrinter.print(events);
+                for (Event event : events) {
+                    switch (count.incrementAndGet()) {
+                    case 1:
+                        AssertJUnit.assertEquals(55.6f, event.getData(1));
+                        break;
+                    case 2:
+                        AssertJUnit.assertEquals(56.6f, event.getData(1));
+                        break;
+                    case 3:
+                        AssertJUnit.assertEquals(100L, event.getData(2));
+                        break;
+                    case 4:
+                        AssertJUnit.assertEquals(200L, event.getData(2));
+                        break;
+                    case 5:
+                        AssertJUnit.assertEquals("wso2", event.getData(0));
+                        break;
+                    case 6:
+                        AssertJUnit.assertEquals(null, event.getData(0));
+                        break;
+                    default:
+                        AssertJUnit.fail();
+                    }
+                }
+            }
+        });
+        siddhiAppRuntime.start();
+        InMemoryBroker.publish("stock", ("\n" +
+                "{\"portfolio\":\n" +
+                "   [" +
+                "       {\"stock\":{\"volume\":100,\"company\":{\"symbol\":\"wso2\"},\"price\":55.6}}," +
+                "       {\"stock\":{\"volume\":null,\"company\":{\"symbol\":\"IBM\"},\"price\":56.6}}" +
+                "   ]\n" +
+                "}\n").getBytes(StandardCharsets.UTF_8));
+        InMemoryBroker.publish("stock", ("\n" +
+                "{\"portfolio\":\n" +
+                "   [" +
+                "       {\"stock\":{\"volume\":100,\"company\":{\"symbol\":\"wso2\"},\"price\":66.6}}," +
+                "       {\"stock\":{\"volume\":200,\"company\":{\"symbol\":\"IBM\"},\"price\":null}}" +
+                "   ]\n" +
+                "}\n").getBytes(StandardCharsets.UTF_8));
+        InMemoryBroker.publish("stock", ("\n" +
+                "{\"portfolio\":\n" +
+                "   [" +
+                "       {\"stock\":{\"volume\":100,\"company\":{\"symbol\":\"wso2\"},\"price\":76.6}}," +
+                "       {\"stock\":{\"volume\":200,\"company\":{\"symbol\":null},\"price\":77.6}}" +
+                "   ]\n" +
+                "}\n").getBytes(StandardCharsets.UTF_8));
+        SiddhiTestHelper.waitForEvents(waitTime, 6, count, timeout);
+        //assert event count
+        AssertJUnit.assertEquals("Number of events", 6, count.get());
         siddhiAppRuntime.shutdown();
     }
 }


### PR DESCRIPTION
## Purpose
> Make binary events supported by the Json mapper

## Approach
> Convert events of the byte array to the corresponding string object and pass to the mapper. 

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes