### PR TITLE
Fixing bug: fail.on.missing.attribute is always set to true

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapper.java
@@ -174,7 +174,7 @@ public class JsonSourceMapper extends SourceMapper {
         this.streamAttributes = this.streamDefinition.getAttributeList();
         attributesSize = this.streamDefinition.getAttributeList().size();
         this.mappingPositions = new MappingPositionData[attributesSize];
-        failOnMissingAttribute = Boolean.parseBoolean(optionHolder.
+        this.failOnMissingAttribute = Boolean.parseBoolean(optionHolder.
                 validateAndGetStaticValue(FAIL_ON_MISSING_ATTRIBUTE_IDENTIFIER, "true"));
         factory = new JsonFactory();
         if (list != null && list.size() > 0) {


### PR DESCRIPTION
Regardless of what has being specified in the siddhi app, fail.on.missing.attribute is set to true.

## Purpose
This PR fixes the issue that  fail.on.missing.attribute is always set to true regardless of what has bein specified in the Siddhi app.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes