### PR TITLE
Upgrade json-smart version to 2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
         <gson.version>2.8.0</gson.version>
         <testng.version>6.8</testng.version>
         <tapestry.json.orbit.version>5.4.1.wso2v1</tapestry.json.orbit.version>
-        <net.minidev.version>2.1.0</net.minidev.version>
+        <net.minidev.version>2.2</net.minidev.version>
         <jacoco.version>0.7.9</jacoco.version>
 
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>


### PR DESCRIPTION
## Purpose
Since there are important fixes in the 2.2 version. we need to upgrade it to 2.2. Please find the fixes available.

    Fix OSGI error fix https://github.com/netplex/json-smart-v2/issues/2
    Add support for BigDecimal
    Improve JSONObject.getAsNumber() helper
    Add a Field Remaper

Resolves #41 

## Goals
Upgrade json-smart version to 2.2

## Approach
Upgrade json-smart version to 2.2

## User stories
NA

## Release note
NA

## Documentation
NA

## Training
NA

## Certification
NA

## Marketing
NA

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
Linux 16.04
java version "1.8.0_161"
Java(TM) SE Runtime Environment (build 1.8.0_161-b12)
Java HotSpot(TM) 64-Bit Server VM (build 25.161-b12, mixed mode)
 
## Learning
NA