### PR TITLE
Fix: top-level field prefix with `@` cause path not found

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapper.java
@@ -204,7 +204,8 @@ public class JsonSourceMapper extends SourceMapper {
                 AttributeMapping attributeMapping = attributeMappingList.get(i);
                 String attributeName = attributeMapping.getName();
                 int position = this.streamDefinition.getAttributePosition(attributeName);
-                this.mappingPositions[i] = new MappingPositionData(position, attributeMapping.getMapping());
+                this.mappingPositions[i] = new MappingPositionData(position,
+                        DEFAULT_JSON_MAPPING_PREFIX + attributeMapping.getMapping());
             }
         } else {
             this.mappingPositions = new MappingPositionData[streamAttributesSize];


### PR DESCRIPTION
## Purpose

With custom mapping(using `@attribute`), and mapping a top-level field prefix with `@`, cause path not found. The root cause is that `@` in JsonPath is a keyword.

## Approach

Add `DEFAULT_JSON_MAPPING_PREFIX` before the user mapping field can fix this issue.

## Automation tests
 - Unit tests 
   `JsonSourceMapperTestCase.jsonSourceMapperTest7` show the case