### PR TITLE
Revert "Fix: top-level field prefix with `@` cause path not found"

### DIFF
--- a/component/src/main/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapper.java
+++ b/component/src/main/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapper.java
@@ -208,8 +208,7 @@ public class JsonSourceMapper extends SourceMapper {
                 AttributeMapping attributeMapping = attributeMappingList.get(i);
                 String attributeName = attributeMapping.getName();
                 int position = this.streamDefinition.getAttributePosition(attributeName);
-                this.mappingPositions[i] = new MappingPositionData(position,
-                        DEFAULT_JSON_MAPPING_PREFIX + attributeMapping.getMapping());
+                this.mappingPositions[i] = new MappingPositionData(position, attributeMapping.getMapping());
             }
         } else {
             this.mappingPositions = new MappingPositionData[streamAttributesSize];

--- a/component/src/test/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapperTestCase.java
+++ b/component/src/test/java/org/wso2/extension/siddhi/map/json/sourcemapper/JsonSourceMapperTestCase.java
@@ -502,51 +502,6 @@ public class JsonSourceMapperTestCase {
     }
 
     @Test
-    public void jsonSourceMapperTest7() throws InterruptedException {
-        log.info("test JsonSourceMapper 7");
-        String streams = "" +
-                "@App:name('TestSiddhiApp')" +
-                "@source(type='inMemory', topic='stock', " +
-                "@map(type='json', fail.on.missing.attribute='true', " +
-                "@attributes(time = '@timestamp' )))\n" +
-                "define stream FooStream (time long); " +
-                "define stream BarStream (time long); ";
-        String query = "" +
-                "from FooStream " +
-                "select * " +
-                "insert into BarStream; ";
-        SiddhiManager siddhiManager = new SiddhiManager();
-        SiddhiAppRuntime siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(streams + query);
-        siddhiAppRuntime.addCallback("BarStream", new StreamCallback() {
-
-            @Override
-            public void receive(Event[] events) {
-                EventPrinter.print(events);
-                for (Event event : events) {
-                    switch (count.incrementAndGet()) {
-                        case 1:
-                            AssertJUnit.assertEquals(1537258337000L, event.getData(0));
-                            break;
-                        default:
-                            AssertJUnit.fail();
-                    }
-                }
-            }
-        });
-        siddhiAppRuntime.start();
-        InMemoryBroker.publish("stock", " {\n" +
-                "         \"@timestamp\": 1537258337000,\n" +
-                "         \"symbol\":\"WSO2\",\n" +
-                "         \"price\":55.6,\n" +
-                "         \"volume\": 100\n" +
-                " }");
-        SiddhiTestHelper.waitForEvents(waitTime, 1, count, timeout);
-        //assert event count
-        AssertJUnit.assertEquals("Number of events", 1, count.get());
-        siddhiAppRuntime.shutdown();
-    }
-
-    @Test
     public void jsonSourceMapperTest8() throws InterruptedException {
         log.info("test JsonSourceMapper 8");
         String streams = "" +


### PR DESCRIPTION
Revert this issue because this is breaking the custom mapping implementation when the mapping is provided with "$".