### PR TITLE
Bump json-path version and Remove the private packaged json-path related dependencies

### DIFF
--- a/component/pom.xml
+++ b/component/pom.xml
@@ -146,9 +146,6 @@
                         <Bundle-Name>${project.artifactId}</Bundle-Name>
                         <Private-Package>
                             org.apache.tapestry5.json.*,
-                            com.jayway.jsonpath.*,
-                            net.minidev.*,
-                            org.objectweb.asm.*,
                             com.google.gson.*
                         </Private-Package>
                         <Export-Package>
@@ -158,6 +155,8 @@
                             io.siddhi.core.*;version="${siddhi.version.range}",
                             io.siddhi.annotation.*;version="${siddhi.version.range}",
                             io.siddhi.query.api.*;version="${siddhi.version.range}",
+                            com.jayway.jsonpath.*;version="${com.jayway.jsonpath.version.range}",
+                            net.minidev.*;version="${net.minidev.json-smart.version.range}",
                             *;resolution:=optional
                         </Import-Package>
                         <Include-Resource>

--- a/pom.xml
+++ b/pom.xml
@@ -178,14 +178,16 @@
     <properties>
         <siddhi.version>5.1.21</siddhi.version>
         <siddhi.version.range>[5.0.0,6.0.0)</siddhi.version.range>
+        <com.jayway.jsonpath.version.range>[2.2.0,3.0.0)</com.jayway.jsonpath.version.range>
+        <net.minidev.json-smart.version.range>[2.5.0,3.0.0)</net.minidev.json-smart.version.range>
         <log4j.version>2.17.1</log4j.version>
         <carbon.feature.plugin.version>3.0.0</carbon.feature.plugin.version>
         <jackson.databind.version>2.9.10.8</jackson.databind.version>
-        <jsonpath.version>2.2.0</jsonpath.version>
+        <jsonpath.version>2.9.0</jsonpath.version>
         <gson.version>2.8.0</gson.version>
         <testng.version>6.8</testng.version>
         <tapestry.json.orbit.version>5.4.1.wso2v1</tapestry.json.orbit.version>
-        <net.minidev.version>2.4.7</net.minidev.version>
+        <net.minidev.version>2.5.0</net.minidev.version>
         <jacoco.version>0.7.9</jacoco.version>
 
         <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>


### PR DESCRIPTION
## Purpose

This PR adds the following changes,

- Bump json-path version to 2.9.0
- Bump json-smart version to 2.5.0
- Remove the private packaged json-path and json-smart dependencies